### PR TITLE
chore: Remove Dependabot commit message prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,6 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
-    commit-message:
-      prefix: "chore"
     schedule:
       interval: "daily"
       time: "07:00"
@@ -19,8 +17,6 @@ updates:
 
   - package-ecosystem: "docker"
     directory: "/"
-    commit-message:
-      prefix: "chore"
     schedule:
       interval: "daily"
       time: "07:00"


### PR DESCRIPTION
Removing the commit message prefix for Dependabot to fall back to normal conventional commit messages provided by Dependabot.