### PR TITLE
chore(main): Update gradle-publish workflow to run on tag creation

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -3,8 +3,8 @@ name: Gradle Package
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - 'v*'
 
 jobs:
   build:


### PR DESCRIPTION
Intention is to avoid the usage of SNAPSHOT versions in the future.