### PR TITLE
chore(main): Use PAT in release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,3 +18,5 @@ jobs:
 
     steps:
       - uses: googleapis/release-please-action@v4.1.1
+        with:
+          token: ${{ secrets.PAT }}


### PR DESCRIPTION
Use a PAT in the release-please workflow to ensure that workflows and required checks are running in the release PR.