### PR TITLE
Remove github-actions[bot] from pull_request_target handling

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -11,14 +11,11 @@ jobs:
   build:
     name: Gradle Package
 
-    # If the PR is coming from a fork (pull_request_target), ensure it's opened by "dependabot[bot]"
-    # or "github-actions[bot]".
+    # If the PR is coming from a fork (pull_request_target), ensure it's opened by "dependabot[bot]".
     # Otherwise, clone it normally.
     if: |
         (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') ||
-        (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]') ||
-        (github.event_name == 'pull_request_target' && github.actor == 'github-actions[bot]') ||
-        (github.event_name != 'pull_request_target' && github.actor != 'github-actions[bot]')
+        (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
     runs-on: ubuntu-22.04
 
     permissions:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,14 +19,11 @@ jobs:
   build:
     name: Gradle build
 
-    # If the PR is coming from a fork (pull_request_target), ensure it's opened by "dependabot[bot]"
-    # or "github-actions[bot]".
+    # If the PR is coming from a fork (pull_request_target), ensure it's opened by "dependabot[bot]".
     # Otherwise, clone it normally.
     if: |
         (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') ||
-        (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]') ||
-        (github.event_name == 'pull_request_target' && github.actor == 'github-actions[bot]') ||
-        (github.event_name != 'pull_request_target' && github.actor != 'github-actions[bot]')
+        (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
     runs-on: ubuntu-22.04
 
     steps:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -9,14 +9,11 @@ jobs:
   build:
     name: Lint Code Base
 
-    # If the PR is coming from a fork (pull_request_target), ensure it's opened by "dependabot[bot]"
-    # or "github-actions[bot]".
+    # If the PR is coming from a fork (pull_request_target), ensure it's opened by "dependabot[bot]".
     # Otherwise, clone it normally.
     if: |
         (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') ||
-        (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]') ||
-        (github.event_name == 'pull_request_target' && github.actor == 'github-actions[bot]') ||
-        (github.event_name != 'pull_request_target' && github.actor != 'github-actions[bot]')
+        (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
     runs-on: ubuntu-22.04
 
     steps:


### PR DESCRIPTION
As it didn't had any effect removing the handling of github-actions[bot] from workflows using pull_request_target.