### PR TITLE
chore(main): Fix Gradle publishing

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -52,3 +52,6 @@ jobs:
 
     - name: Publish to GitHub Packages
       run: ./gradlew publish
+      env:
+        USERNAME: ${{ github.actor }}
+        TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add back the environment variables needed for publishing to GitHub Packages.